### PR TITLE
Support stdin for running scans

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -40,7 +40,8 @@ jobs:
       env:
         OCHRONA_API_KEY: ${{ secrets.OCHRONA_API_KEY }}
       run: |
-        ochrona --file requirements.txt
+        ochrona --file requirements.txt --project_name Ochrona-CLI
+        ochrona --file requirements-dev.txt --project_name Ochrona-CLI-Dev
     - name: Coverage
       run: |
         codecov

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.1.1
+- Allow ochrona to accept piped input
+
 ## 0.1.0
 - Updated to support new authentication provider
 

--- a/ochrona/__init__.py
+++ b/ochrona/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 __author__ = """ascott"""
 __email__ = "andrew@ochrona.dev"
-__version__ = "0.1.0"
+__version__ = "0.1.1"

--- a/ochrona/file_handler.py
+++ b/ochrona/file_handler.py
@@ -154,3 +154,23 @@ def parse_to_payload(
         return {"dependencies": dependencies, "project_name": config.project_name}
     else:
         return {"dependencies": dependencies}
+
+
+def parse_direct_to_payload(
+    logger: OchronaLogger, direct: str, config: OchronaConfig
+) -> Dict[str, Any]:
+    """
+    Parses direct input string as PEP-508 compliant file and outputs a JSON payload.
+    :param logger: A configured `OchronaLogger` instance
+    :param direct: input string
+    :param config: An instance of `OchronaConfig`
+    :return: JSON payload
+    """
+    dependencies = []
+    parsers = Parsers()
+    dependencies = parsers.requirements.direct_parse(direct=direct)
+    logger.debug(f"Discovered dependencies: {dependencies}")
+    if config.project_name is not None:
+        return {"dependencies": dependencies, "project_name": config.project_name}
+    else:
+        return {"dependencies": dependencies}

--- a/ochrona/parsers/requirements.py
+++ b/ochrona/parsers/requirements.py
@@ -44,7 +44,7 @@ class RequirementsFile:
                 )
             ]
         except OSError as ex:
-            raise OchronaFileException(f"OS error when parsing {file_path}") from ex
+            raise OchronaFileException(f"OS error when parsing {direct}") from ex
 
     @staticmethod
     def clean_dependency(dependency: str) -> str:

--- a/ochrona/parsers/requirements.py
+++ b/ochrona/parsers/requirements.py
@@ -27,6 +27,26 @@ class RequirementsFile:
             raise OchronaFileException(f"OS error when parsing {file_path}") from ex
 
     @staticmethod
+    def direct_parse(direct: str) -> List[str]:
+        """
+        Parses a requirements.txt style string into a list of requirements.
+
+        :param file_path: requirements*.txt file path.
+        :return: list<str> list of dependencies ['dependency==semvar']
+        """
+        try:
+            deps = direct.split("\n")
+            return [
+                RequirementsFile.clean_dependency(dep)
+                for dep in deps
+                if not any(
+                    [dep.strip().startswith(s) for s in INVALID_REQUIREMENTS_LINES]
+                )
+            ]
+        except OSError as ex:
+            raise OchronaFileException(f"OS error when parsing {file_path}") from ex
+
+    @staticmethod
     def clean_dependency(dependency: str) -> str:
         """
         Removes any comments or hashes following the dependency.

--- a/ochrona/reporter.py
+++ b/ochrona/reporter.py
@@ -37,6 +37,8 @@ class OchronaReporter:
         :return: sys.exit -1 if vulns are discovered
         """
         reports = []
+        if len(sources) == 0:
+            sources.append("stdin")
         for index, (source, result) in enumerate(zip(sources, results)):
             if "confirmed_vulnerabilities" in result:
                 result["confirmed_vulnerabilities"] = list(

--- a/tests/cassettes/TestCli.test_cli_pass_empty_requirements.yaml
+++ b/tests/cassettes/TestCli.test_cli_pass_empty_requirements.yaml
@@ -1,0 +1,41 @@
+interactions:
+- request:
+    body: '{"dependencies": [""]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - None
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '22'
+      Content-Type:
+      - application/json
+      Host:
+      - api.ochrona.dev
+      User-Agent:
+      - OchronaClient/0.1.1/3.7.3
+    method: POST
+    uri: http://localhost:5000/python/analyze
+  response:
+    body:
+      string: '{"dependencies": [{"name": "", "full": "", "latest_version": "", "license_type":
+        "Unknown"}], "flat_list": [""]}'
+    headers:
+      Content-Length:
+      - '112'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Mar 2021 16:01:44 GMT
+      Server:
+      - Werkzeug/0.15.5 Python/3.7.3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/cassettes/TestCli.test_cli_pass_stdin.yaml
+++ b/tests/cassettes/TestCli.test_cli_pass_stdin.yaml
@@ -1,0 +1,43 @@
+interactions:
+- request:
+    body: '{"dependencies": ["requests==2.22.0"]}'
+    headers:
+      Accept:
+      - '*/*'
+      Accept-Encoding:
+      - gzip, deflate
+      Authorization:
+      - None
+      Cache-Control:
+      - no-cache
+      Connection:
+      - keep-alive
+      Content-Length:
+      - '38'
+      Content-Type:
+      - application/json
+      Host:
+      - api.ochrona.dev
+      User-Agent:
+      - OchronaClient/0.1.1/3.7.3
+    method: POST
+    uri: http://localhost:5000/python/analyze
+  response:
+    body:
+      string: '{"dependencies": [{"name": "requests", "version": "2.22.0", "version_major":
+        "2", "version_minor": "22", "version_release": "0", "operator": "==", "full":
+        "requests==2.22.0", "latest_version": "2.25.1", "license_type": "Apache-2.0"}],
+        "flat_list": ["requests==2.22.0"]}'
+    headers:
+      Content-Length:
+      - '269'
+      Content-Type:
+      - application/json
+      Date:
+      - Sat, 13 Mar 2021 16:01:44 GMT
+      Server:
+      - Werkzeug/0.15.5 Python/3.7.3
+    status:
+      code: 200
+      message: OK
+version: 1

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -32,7 +32,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_fail(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -47,7 +47,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_fail_clean_exit(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -63,7 +63,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_pass_single_requirements(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -78,7 +78,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_pass_single_pipfile(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -93,7 +93,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_pass_empty_requirements(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -107,8 +107,22 @@ class TestCli:
             assert result.exit_code == 0
 
     @pytest.mark.vcr()
+    def test_cli_pass_stdin(self):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
+            runner = CliRunner()
+            result = runner.invoke(
+                cli.run,
+                [
+                    "requests==2.22.0",
+                    "--api_key",
+                    "1234",
+                ],
+            )
+            assert result.exit_code == 0
+
+    @pytest.mark.vcr()
     def test_cli_pass_fail_ignore_package(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -125,7 +139,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_pass_fail_ignore_cve(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,
@@ -142,7 +156,7 @@ class TestCli:
 
     @pytest.mark.vcr()
     def test_cli_pass_fail_ignore_no_match(self):
-        with mock.patch.object(OchronaConfig, '_get_session', return_value=None):
+        with mock.patch.object(OchronaConfig, "_get_session", return_value=None):
             runner = CliRunner()
             result = runner.invoke(
                 cli.run,

--- a/tests/test_import_wrapper.py
+++ b/tests/test_import_wrapper.py
@@ -8,7 +8,6 @@ from ochrona.exceptions import OchronaImportException
 
 
 class MockLogger:
-
     def __init__(self):
         self._info = []
         self._warn = []
@@ -157,7 +156,10 @@ class TestImportWrapper:
         install_file.assert_called_once()
         install.assert_not_called()
         assert len(client._analyzed) == 1
-        assert client._analyzed[0] == '{"dependencies": ["requests==2.22.0", "Click==7.0", "Flask==1.1.1", "itsdangerous==1.1.0", "Jinja2==2.10.1", "MarkupSafe==1.1.1", "Werkzeug==0.15.4"]}'
+        assert (
+            client._analyzed[0]
+            == '{"dependencies": ["requests==2.22.0", "Click==7.0", "Flask==1.1.1", "itsdangerous==1.1.0", "Jinja2==2.10.1", "MarkupSafe==1.1.1", "Werkzeug==0.15.4"]}'
+        )
         assert (
             logger._info[0]
             == "A full list of packages to be installed, included dependencies: requests==2.22.0, Click==7.0, Flask==1.1.1, itsdangerous==1.1.0, Jinja2==2.10.1, MarkupSafe==1.1.1, Werkzeug==0.15.4"
@@ -195,7 +197,10 @@ class TestImportWrapper:
         install_file.assert_not_called()
         install.assert_not_called()
         assert len(client._analyzed) == 1
-        assert client._analyzed[0] == '{"dependencies": ["requests==2.19.0", "Click==7.0", "Flask==1.1.1", "itsdangerous==1.1.0", "Jinja2==2.10.1", "MarkupSafe==1.1.1", "Werkzeug==0.15.4"]}'
+        assert (
+            client._analyzed[0]
+            == '{"dependencies": ["requests==2.19.0", "Click==7.0", "Flask==1.1.1", "itsdangerous==1.1.0", "Jinja2==2.10.1", "MarkupSafe==1.1.1", "Werkzeug==0.15.4"]}'
+        )
         assert (
             logger._info[0]
             == "A full list of packages that would be installed, included dependencies: requests==2.19.0, Click==7.0, Flask==1.1.1, itsdangerous==1.1.0, Jinja2==2.10.1, MarkupSafe==1.1.1, Werkzeug==0.15.4"

--- a/tests/test_reporter.py
+++ b/tests/test_reporter.py
@@ -106,7 +106,13 @@ class TestOchronaReporter:
             {
                 "flat_list": ["fake"],
                 "confirmed_vulnerabilities": [
-                    {"found_version": "fake", "description": "fake finding", "cve_id": "123", "name": "fake", "ochrona_severity_score": 8.4}
+                    {
+                        "found_version": "fake",
+                        "description": "fake finding",
+                        "cve_id": "123",
+                        "name": "fake",
+                        "ochrona_severity_score": 8.4,
+                    }
                 ],
             },
             0,


### PR DESCRIPTION
This should add support for ad-hoc scanning like ```ochrona requests==2.22.0``` or piped input ```pipenv lock -r | ochrona```