### PR TITLE
Stdin click bug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Change Log
 
+## 0.1.2
+- In some interpreters click accepts an empty string as an arguments, while others return None 
+
 ## 0.1.1
 - Allow ochrona to accept piped input
 

--- a/ochrona/__init__.py
+++ b/ochrona/__init__.py
@@ -1,4 +1,4 @@
 # -*- coding: utf-8 -*-
 __author__ = """ascott"""
 __email__ = "andrew@ochrona.dev"
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/ochrona/cli.py
+++ b/ochrona/cli.py
@@ -127,7 +127,7 @@ def run(
             log.header()
 
         try:
-            if direct is None:
+            if direct is None or direct == "":
                 files = rfind_all_dependencies_files(
                     log, config.dir, config.exclude_dir, config.file
                 )
@@ -146,7 +146,7 @@ def run(
                 else:
                     # can't leave empty otherwise result counts are off
                     results.append(client.empty_result())
-            if direct is not None:
+            if direct is not None or direct != "":
                 # use piped input directly and treat as PEP-508 format
                 payload = parse_direct_to_payload(log, direct, config)
                 if payload.get("dependencies") != []:

--- a/ochrona/cli.py
+++ b/ochrona/cli.py
@@ -126,8 +126,9 @@ def run(
         if not config.silent:
             log.header()
 
+        direct = direct if direct != "" else None
         try:
-            if direct is None or direct == "":
+            if direct is None:
                 files = rfind_all_dependencies_files(
                     log, config.dir, config.exclude_dir, config.file
                 )
@@ -146,7 +147,7 @@ def run(
                 else:
                     # can't leave empty otherwise result counts are off
                     results.append(client.empty_result())
-            if direct is not None or direct != "":
+            if direct is not None:
                 # use piped input directly and treat as PEP-508 format
                 payload = parse_direct_to_payload(log, direct, config)
                 if payload.get("dependencies") != []:


### PR DESCRIPTION
The new sdtin change is causing some interpreters, namely github actions, to return an empty string, rather than None, when a file is provided